### PR TITLE
fix: correct the path for switch root target

### DIFF
--- a/dropbear.py
+++ b/dropbear.py
@@ -9,7 +9,7 @@ from zenlib.util import contains
 def drop_the_bear(self) -> str:
     """Returns shell lines to kill the dropbear server if the switch_root_target is mounted"""
     return """
-    if [ -n "$(awk '$2 == "'"$(cat /run/vars/SWITCH_ROOT_TARGET)"'" {print $2}' /proc/mounts)" ]; then
+    if [ -n "$(awk '$2 == "'"$(readvar SWITCH_ROOT_TARGET)"'" {print $2}' /proc/mounts)" ]; then
         einfo "Switch root target mounted, killing dropbear."
         kill -9 $(cat /run/dropbear.pid)
         return


### PR DESCRIPTION
Without this I could not boot.

My command line:
```
GRUB_CMDLINE_LINUX="rootfstype=ext4 rootflags=rw,relatime quiet"
```
Config file:

```
$ cat /etc/ugrd/config.toml
kmod_autodetect_lspci = true

modules = [
    "ugrd.base.base",
    "ugrd.crypto.cryptsetup",
    "ugrd.fs.lvm",
    "ugrd.fs.resume",
    "ugrd.net.static",
    "dropbear",
]

binaries = [ "sleep" ]
cryptsetup_trim = true
net_device = "enp0s25"
net_device_mac = "98:90:96:c7:77:96"
ip_address = "192.168.0.120/24"
ip_gateway = "192.168.0.1"
dropbear_authorized_keys = "/root/.ssh/authorized_keys"

[cryptsetup.luks-0d13a32c-6b38-4f1c-93a6-07758d01c02f]
uuid = "0d13a32c-6b38-4f1c-93a6-07758d01c02f"
```

Fix #2 .